### PR TITLE
exclude malloc in 02_strlen_long_str_test.c

### DIFF
--- a/real-tests/ft_strlen/02_strlen_long_str_test.c
+++ b/real-tests/ft_strlen/02_strlen_long_str_test.c
@@ -6,7 +6,7 @@
 /*   By: tarata <tarata@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/11 01:28:52 by tarata            #+#    #+#             */
-/*   Updated: 2021/05/14 19:40:55 by tarata           ###   ########.fr       */
+/*   Updated: 2021/05/14 23:28:08 by tarata           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,17 +14,15 @@
 
 int	ft_check_long_str(void)
 {
-	char	*str;
+	char	str[1001];
 	int		ret;
 
-	str = malloc(sizeof(char) * (1000 + 1));
 	memset(str, 'a', 1000);
 	str[1000] = '\0';
 	if (ft_strlen(str) == strlen(str))
 		ret = 1;
 	else
 		ret = 0;
-	free(str);
 	return (ret);
 }
 


### PR DESCRIPTION
Makefile のsanitize=address と02_strlen_long_str_test.cでの mallocを静的な確保に置き換えました。